### PR TITLE
Added variable for s3 object ownership

### DIFF
--- a/endpoints.tf
+++ b/endpoints.tf
@@ -1,6 +1,7 @@
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "s3" {
+  count           = var.create_s3_endpoint ? 1 : 0
   vpc_id          = module.vpc.vpc_id
   service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
   route_table_ids = concat(module.dynamic_subnets.private_route_table_ids, module.dynamic_subnets.public_route_table_ids)

--- a/main.tf
+++ b/main.tf
@@ -28,4 +28,5 @@ module "flow_logs" {
   name                = "flowlogs"
   vpc_id              = module.vpc.vpc_id
   s3_object_ownership = var.s3_object_ownership
+  bucket_name         = "${var.name}-${var.stage}-VPC-flowlogs"
 }

--- a/main.tf
+++ b/main.tf
@@ -28,5 +28,5 @@ module "flow_logs" {
   name                = "flowlogs"
   vpc_id              = module.vpc.vpc_id
   s3_object_ownership = var.s3_object_ownership
-  bucket_name         = "${var.stage}-${var.region}-${var.name}-flowlogs"
+  bucket_name         = "${var.namespace}-${var.stage}-${var.region}-${var.name}-flowlogs"
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source             = "cloudposse/dynamic-subnets/aws"
-  version            = "0.39.3"
+  version            = "1.0.0"
   namespace          = var.namespace
   stage              = var.stage
   name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -28,5 +28,5 @@ module "flow_logs" {
   name                = "flowlogs"
   vpc_id              = module.vpc.vpc_id
   s3_object_ownership = var.s3_object_ownership
-  bucket_name         = "${var.name}-${var.stage}-VPC-flowlogs"
+  bucket_name         = "${var.name}-${var.stage}-account-flowlogs"
 }

--- a/main.tf
+++ b/main.tf
@@ -26,4 +26,5 @@ module "flow_logs" {
   stage     = var.stage
   name      = "flowlogs"
   vpc_id    = module.vpc.vpc_id
+  s3_object_ownership = var.s3_object_ownership
 }

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  ipv4_cidr_block    = var.cidr_block
+  ipv4_cidr_block    = [var.cidr_block]
 }
 
 module "flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -28,5 +28,5 @@ module "flow_logs" {
   name                = "flowlogs"
   vpc_id              = module.vpc.vpc_id
   s3_object_ownership = var.s3_object_ownership
-  bucket_name         = "${var.name}-${var.stage}-account-flowlogs"
+  bucket_name         = "${var.name}-${var.stage}-${var.region}-account-flowlogs"
 }

--- a/main.tf
+++ b/main.tf
@@ -16,15 +16,15 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  ipv4_cidr_block         = var.cidr_block
+  ipv4_cidr_block    = var.cidr_block
 }
 
 module "flow_logs" {
-  source    = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  version   = "1.0.1"
-  namespace = var.namespace
-  stage     = var.stage
-  name      = "flowlogs"
-  vpc_id    = module.vpc.vpc_id
+  source              = "cloudposse/vpc-flow-logs-s3-bucket/aws"
+  version             = "1.0.1"
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = "flowlogs"
+  vpc_id              = module.vpc.vpc_id
   s3_object_ownership = var.s3_object_ownership
 }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "dynamic_subnets" {
 
 module "flow_logs" {
   source    = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  version   = "0.12.1"
+  version   = "0.18.0"
   namespace = var.namespace
   stage     = var.stage
   name      = "flowlogs"

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "dynamic_subnets" {
   # name               = var.name
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
-  igw_id             = module.vpc.igw_id
+  igw_id             = [module.vpc.igw_id]
   ipv4_cidr_block    = [var.cidr_block]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source     = "cloudposse/vpc/aws"
-  version    = "0.26.1"
+  version    = "2.1.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source    = "cloudposse/dynamic-subnets/aws"
-  version   = "0.39.3"
+  version   = "2.4.1"
   namespace = var.namespace
   stage     = var.stage
   # name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ module "dynamic_subnets" {
   name               = var.name
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
-  igw_id             = [module.vpc.igw_id]
-  cidr_block         = [var.cidr_block]
+  igw_id             = module.vpc.igw_id
+  cidr_block         = var.cidr_block
   tags               = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,14 +9,14 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source             = "cloudposse/dynamic-subnets/aws"
-  version            = var.dynamic_subnets_version
+  version            = "2.1.0"
   namespace          = var.namespace
   stage              = var.stage
   name               = var.name
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
-  igw_id             = module.vpc.igw_id
-  cidr_block         = var.cidr_block
+  igw_id             = [module.vpc.igw_id]
+  ipv4_cidr_block    = [var.cidr_block]
   tags               = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source             = "cloudposse/dynamic-subnets/aws"
-  version            = "2.1.0"
+  version            = "2.4.1"
   namespace          = var.namespace
   stage              = var.stage
   name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -28,5 +28,5 @@ module "flow_logs" {
   name                = "flowlogs"
   vpc_id              = module.vpc.vpc_id
   s3_object_ownership = var.s3_object_ownership
-  bucket_name         = "${var.name}-${var.stage}-${var.region}-account-flowlogs"
+  bucket_name         = "${var.stage}-${var.region}-${var.name}-flowlogs"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "2.1.0"
-  namespace  = var.namespace
-  stage      = var.stage
-  name       = var.name
-  cidr_block = var.cidr_block
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  namespace               = var.namespace
+  stage                   = var.stage
+  name                    = var.name
+  ipv4_primary_cidr_block = var.cidr_block
 }
 
 module "dynamic_subnets" {

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  cidr_block         = var.cidr_block
+  ipv4_cidr_block         = var.cidr_block
 }
 
 module "flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ module "vpc" {
 }
 
 module "dynamic_subnets" {
-  source    = "cloudposse/dynamic-subnets/aws"
-  version   = "2.4.1"
-  namespace = var.namespace
-  stage     = var.stage
-  # name               = var.name
+  source             = "cloudposse/dynamic-subnets/aws"
+  version            = "2.4.1"
+  namespace          = var.namespace
+  stage              = var.stage
+  name               = var.name
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = [module.vpc.igw_id]

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ module "dynamic_subnets" {
   vpc_id             = module.vpc.vpc_id
   igw_id             = [module.vpc.igw_id]
   ipv4_cidr_block    = [var.cidr_block]
+  tags               = var.tags
 }
 
 module "flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source             = "cloudposse/dynamic-subnets/aws"
-  # version            = "2.4.1"
+  version            = "0.39.3"
   namespace          = var.namespace
   stage              = var.stage
   name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source    = "cloudposse/dynamic-subnets/aws"
-  version   = "2.4.1"
+  version   = "2.3.9"
   namespace = var.namespace
   stage     = var.stage
   # name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "dynamic_subnets" {
 
 module "flow_logs" {
   source    = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  version   = "0.18.0"
+  version   = "1.0.1"
   namespace = var.namespace
   stage     = var.stage
   name      = "flowlogs"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source             = "cloudposse/dynamic-subnets/aws"
-  version            = "2.4.1"
+  # version            = "2.4.1"
   namespace          = var.namespace
   stage              = var.stage
   name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source             = "cloudposse/dynamic-subnets/aws"
-  version            = "1.0.0"
+  version            = var.dynamic_subnets_version
   namespace          = var.namespace
   stage              = var.stage
   name               = var.name

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = [module.vpc.igw_id]
-  ipv4_cidr_block    = [var.cidr_block]
+  cidr_block         = [var.cidr_block]
   tags               = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source    = "cloudposse/dynamic-subnets/aws"
-  version   = "2.3.9"
+  version   = "2.4.1"
   namespace = var.namespace
   stage     = var.stage
   # name               = var.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,9 +11,9 @@ output "public_subnets" {
   value = join(", ", module.dynamic_subnets.public_subnet_ids)
 }
 
-output "route_table_ids" {
+/* output "route_table_ids" {
   value = concat(module.dynamic_subnets.private_route_table_ids, module.dynamic_subnets.public_route_table_ids)
-}
+} */
 
 output "igw_id" {
   value       = module.vpc.igw_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "igw_id" {
   description = "Internet Gateway ID"
 }
 
-output "s3_bucket_id" {
-  value       = module.flow_logs.s3_bucket_id
+output "logflow_bucket_id" {
+  value       = module.flow_logs.bucket_id
   description = "S3 Bucket ID"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,3 +14,13 @@ output "public_subnets" {
 output "route_table_ids" {
   value = concat(module.dynamic_subnets.private_route_table_ids, module.dynamic_subnets.public_route_table_ids)
 }
+
+output "igw_id" {
+  value       = module.vpc.igw_id
+  description = "Internet Gateway ID"
+}
+
+output "s3_bucket_id" {
+  value       = module.flow_logs.s3_bucket_id
+  description = "S3 Bucket ID"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,9 +11,9 @@ output "public_subnets" {
   value = join(", ", module.dynamic_subnets.public_subnet_ids)
 }
 
-/* output "route_table_ids" {
+output "route_table_ids" {
   value = concat(module.dynamic_subnets.private_route_table_ids, module.dynamic_subnets.public_route_table_ids)
-} */
+}
 
 output "igw_id" {
   value       = module.vpc.igw_id

--- a/variables.tf
+++ b/variables.tf
@@ -40,5 +40,5 @@ variable "availability_zones" {
 variable "s3_object_ownership" {
   type        = string
   description = "S3 object ownership"
-  default     = "BucketOwnerPreferred"
+  default     = "BucketOwnerEnforced"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,8 +53,3 @@ variable "tags" {
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
   default     = {}
 }
-
-variable "dynamic_subnets_version" {
-  description = "Dynamic subnets version"
-  type        = string
-}

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,9 @@ variable "availability_zones" {
   description = "Availability zones to use"
   default     = ["us-west-2a", "us-west-2b", "us-west-2c"]
 }
+
+variable "s3_object_ownership" {
+  type        = string
+  description = "S3 object ownership"
+  default     = "BucketOwnerPreferred"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
+variable "region" {
+  type = string
+  description = "Region"
+}
+
 #-----------------------------------
 #    Networking
 #-----------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,8 @@ variable "tags" {
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
   default     = {}
 }
+
+variable "dynamic_subnets_version" {
+  description = "Dynamic subnets version"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "stage" {
 }
 
 variable "region" {
-  type = string
+  type        = string
   description = "Region"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,8 @@ variable "tags" {
   description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
   default     = {}
 }
+
+variable "create_s3_endpoint" {
+  type = bool
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,9 @@ variable "s3_object_ownership" {
   description = "S3 object ownership"
   default     = "BucketOwnerEnforced"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
+  default     = {}
+}


### PR DESCRIPTION
Default of BucketOwnerPreferred is for backwards compatibility. Recommended setting is BucketOwnerEnforced, which will be used if you pass in null.

We need BucketOwnerPreferred ownership setting as default for certain deployments into customer accounts. This will require an additional declaration for  to network modules that require any other bucket object ownership. s3_object_ownership