### PR TITLE
Task/updates external modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source     = "cloudposse/vpc/aws"
-  version    = "0.26.1"
+  version    = "2.1.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "dynamic_subnets" {
   source    = "cloudposse/dynamic-subnets/aws"
-  version   = "0.39.3"
+  version   = "2.4.1"
   namespace = var.namespace
   stage     = var.stage
   # name               = var.name
@@ -21,7 +21,7 @@ module "dynamic_subnets" {
 
 module "flow_logs" {
   source    = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  version   = "0.12.1"
+  version   = "2.4.1"
   namespace = var.namespace
   stage     = var.stage
   name      = "flowlogs"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "dynamic_subnets" {
 
 module "flow_logs" {
   source    = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-  version   = "2.4.1"
+  version   = "1.0.1"
   namespace = var.namespace
   stage     = var.stage
   name      = "flowlogs"

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  cidr_block         = var.cidr_block
+  ipv4_cidr_block    = var.ipv4_cidr_block
 }
 
 module "flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  cidr_block         = var.ipv4_cidr_block
+  ipv4_cidr_block    = var.cidr_block
 }
 
 module "flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  ipv4_cidr_block    = var.cidr_block
+  ipv4_cidr_block    = [var.cidr_block]
 }
 
 module "flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "dynamic_subnets" {
   # name               = var.name
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
-  igw_id             = module.vpc.igw_id
+  igw_id             = [module.vpc.igw_id]
   ipv4_cidr_block    = [var.cidr_block]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "2.1.0"
-  namespace  = var.namespace
-  stage      = var.stage
-  name       = var.name
-  cidr_block = var.cidr_block
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  namespace               = var.namespace
+  stage                   = var.stage
+  name                    = var.name
+  ipv4_primary_cidr_block = var.cidr_block
 }
 
 module "dynamic_subnets" {
@@ -16,7 +16,7 @@ module "dynamic_subnets" {
   availability_zones = var.availability_zones
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id
-  ipv4_cidr_block    = var.ipv4_cidr_block
+  cidr_block         = var.ipv4_cidr_block
 }
 
 module "flow_logs" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,9 +26,9 @@ variable "stage" {
 #    Networking
 #-----------------------------------
 
-variable "cidr_block" {
+variable "ipv4_cidr_block" {
   type        = string
-  description = "Cidr block of the VPC"
+  description = "ipv4 Cidr block of the VPC"
 }
 
 variable "availability_zones" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,9 +26,9 @@ variable "stage" {
 #    Networking
 #-----------------------------------
 
-variable "ipv4_cidr_block" {
+variable "cidr_block" {
   type        = string
-  description = "ipv4 Cidr block of the VPC"
+  description = "Cidr block of the VPC"
 }
 
 variable "availability_zones" {


### PR DESCRIPTION
Bumps Cloudposse modules to their latest versions.

vpc = 2.10
dynamic subnets = 2.4.1
flow logs = 1.0.1

Still can takes var.cidr_block but translates them into new expected vars/types,

both modules replaced cidr_block with two new attributes. 

-  ipv4_primary_cidr_block for the vpc module
-  [ipv4_cidr_block] for the dynamic subnets module
- [igw_id] for the dynamic subnets module