### PR TITLE
Exposing CIDR Blocks in outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "vpc_id" {
   description = "VPC ID"
 }
 
+output "vpc_cidr_block" {
+  value       = module.vpc.vpc_cidr_block
+  description = "VPC CIDR Block"
+}
+
+output "additional_cidr_blocks" {
+  value       = module.vpc.additional_cidr_blocks
+  description = "Additional VPC CIDR Blocks"
+}
+
 output "private_subnets" {
   value = join(", ", module.dynamic_subnets.private_subnet_ids)
 }


### PR DESCRIPTION
Simplify the output of CIDR blocks so we do not have to do a separate data lookup.